### PR TITLE
Fix error compilation in newer Elixir versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,10 +3,10 @@ defmodule Pit.Mixfile do
 
   def project do
     [app: :pit,
-     version: "1.2.0",
+     version: "1.2.1",
      elixir: "~> 1.3",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps()]


### PR DESCRIPTION
In newer versions, using functions with arity 0 without parenthesis is not permitted. So, we're adding the ending parenthesis for both `description` and `package`, as well as bumping the patch version of the library.